### PR TITLE
fix: mycomment null when custom tags

### DIFF
--- a/src/org/wanxp/douban/data/handler/DoubanBookLoadHandler.ts
+++ b/src/org/wanxp/douban/data/handler/DoubanBookLoadHandler.ts
@@ -133,7 +133,7 @@ export default class DoubanBookLoadHandler extends DoubanAbstractLoadHandler<Dou
 	}
 
 	private getComment(html: CheerioAPI) {
-		let comment = html('span#rating').next().next().next().text().trim();
+		const comment = html("#interest_sect_level > div > span:last-child").text().trim();
 		if (comment) {
 			return comment;
 		}


### PR DESCRIPTION
## 描述

或许有更好的解决方案，仅仅是处理了 mycomment，而没有处理 tags 为空的问题，不过当前算是解决我这边的首要问题了。

当前 Selector 改为使用 `"#interest_sect_level > div > span:last-child"`

（非常感谢你的插件，帮我将豆瓣的评论同步到 Obsidian，以至于可以让我展开下一步的知识管理工作）

## 基于如下页面

<img width="1116" alt="image" src="https://github.com/user-attachments/assets/51224622-6991-486c-bd04-6b68cec39248">

## 测试

测试了 80 多个，有自定义和没自定义标签都试过是可以的（不过就仅同步了看过的作品）