### PR TITLE
Fix: remove leading and and trailing whitespace of person name

### DIFF
--- a/src/org/wanxp/douban/data/handler/DoubanAbstractLoadHandler.ts
+++ b/src/org/wanxp/douban/data/handler/DoubanAbstractLoadHandler.ts
@@ -207,7 +207,7 @@ export default abstract class DoubanAbstractLoadHandler<T extends DoubanSubject>
 			default:
 				resultName = name;
 		}
-		return resultName;
+		return resultName.trim();
 	}
 
 	getTitleNameByMode(name: string, personNameMode: string, context: HandleContext): string {


### PR DESCRIPTION
感谢作者开发和分享的插件，辛苦 review 一下 PR

## 问题描述

在抓取电影、电视剧等内容时，如果「人名显示模式」设置为「中文名」会导致最后输出的名字后有一个多余的空格。

比如电视剧 《搞笑一家人》的 author 最后会是 `金秉旭 ` （多一个空格），如果基于该属性值来生成双链并创建文件的话，最后的文件名也会多出一个空格

## 解决方案

`DoubanAbstractLoadHandler.getPersonNameByMode` 最后的输出值增加了 `trim` 处理 

## 相关 issue

#92 

#90 