### PR TITLE
fix: 修复图书个人状态字段解析

### DIFF
--- a/src/org/wanxp/douban/data/handler/DoubanAbstractLoadHandler.ts
+++ b/src/org/wanxp/douban/data/handler/DoubanAbstractLoadHandler.ts
@@ -381,7 +381,7 @@ export default abstract class DoubanAbstractLoadHandler<T extends DoubanSubject>
 				DoubanUserParameterName.MY_STATE,
 				DataValueType.string,
 				userState.state,
-				this.getUserStateName(userState.state)
+				userState.stateName || this.getUserStateName(userState.state)
 			));
 		}
 		if (userState.rate) {

--- a/src/org/wanxp/douban/data/handler/DoubanBookLoadHandler.ts
+++ b/src/org/wanxp/douban/data/handler/DoubanBookLoadHandler.ts
@@ -46,11 +46,11 @@ export default class DoubanBookLoadHandler extends DoubanAbstractLoadHandler<Dou
 
 	analysisUser(html: CheerioAPI, context: HandleContext): {data:CheerioAPI ,  userState: UserStateSubject} {
 		const rate = html('input#n_rating').val();
-		const tagsStr = html('span#rating').next().text().trim();
-		const tags = tagsStr ? tagsStr.replace('标签:', '').trim().split(' ') : null;
+		const tags = this.getTags(html);
 		const stateWord = html('div#interest_sect_level > div.a_stars > span.mr10').text().trim();
 		const collectionDateStr = html('div#interest_sect_level > div.a_stars > span.mr10').next().text().trim();
 		const userState1 = DoubanAbstractLoadHandler.getUserState(stateWord);
+		const stateName = this.getBookStateName(stateWord);
 		const comment = this.getComment(html);
 
 
@@ -58,10 +58,47 @@ export default class DoubanBookLoadHandler extends DoubanAbstractLoadHandler<Dou
 			tags: tags,
 			rate: rate?Number(rate):null,
 			state: userState1,
+			stateName: stateName,
 			collectionDate: collectionDateStr?moment(collectionDateStr, 'YYYY-MM-DD').toDate():null,
 			comment: comment
 		}
 		return {data: html, userState: userState};
+	}
+
+	private getTags(html: CheerioAPI): string[] {
+		// Tags are no longer adjacent to #rating on current book pages; find the
+		// labeled "标签:" text inside the user-state block instead.
+		const tagsText = html('#interest_sect_level span.color_gray')
+			.get()
+			.map(span => html(span).text().trim())
+			.find(text => /^标签[:：]/.test(text));
+		if (!tagsText) {
+			return null;
+		}
+		const tags = tagsText
+			.replace(/^标签[:：]/, '')
+			.trim()
+			.split(/\s+/)
+			.filter(tag => tag);
+		return tags.length > 0 ? tags : null;
+	}
+
+	private getBookStateName(stateWord: string): string {
+		// Keep the internal wish/do/collect enum, but expose book-specific Chinese
+		// wording for {{myState}} so it does not depend on the plugin locale.
+		if (!stateWord) {
+			return '';
+		}
+		if (stateWord.indexOf('想读') >= 0) {
+			return '想读';
+		}
+		if (stateWord.indexOf('在读') >= 0) {
+			return '在读';
+		}
+		if (stateWord.indexOf('读过') >= 0) {
+			return '读过';
+		}
+		return '';
 	}
 
 
@@ -133,11 +170,36 @@ export default class DoubanBookLoadHandler extends DoubanAbstractLoadHandler<Dou
 	}
 
 	private getComment(html: CheerioAPI) {
-		let comment = html('span#rating').next().next().next().text().trim();
+		// Douban book pages render the user comment as a plain span alongside
+		// state/date/tag/rating labels, so filter metadata labels before choosing it.
+		let comment = html('#interest_sect_level span')
+			.get()
+			.map(span => html(span).text().trim())
+			.filter(text => this.isCommentCandidate(text))
+			.pop();
 		if (comment) {
 			return comment;
 		}
 		return this.getPropertyValue(html, PropertyName.comment);
+	}
+
+	private isCommentCandidate(text: string): boolean {
+		if (!text) {
+			return false;
+		}
+		if (/^\d{4}-\d{2}-\d{2}$/.test(text)) {
+			return false;
+		}
+		if (/^标签[:：]/.test(text)) {
+			return false;
+		}
+		if (/^(我的)?评价[:：]?$/.test(text)) {
+			return false;
+		}
+		if (text.indexOf('我读过这本书') >= 0 || text.indexOf('我想读这本书') >= 0 || text.indexOf('我在读这本书') >= 0) {
+			return false;
+		}
+		return true;
 	}
 
 

--- a/src/org/wanxp/douban/data/model/UserStateSubject.ts
+++ b/src/org/wanxp/douban/data/model/UserStateSubject.ts
@@ -4,6 +4,7 @@ export interface UserStateSubject {
 	tags: string[];
 	rate: number;
 	state: DoubanSubjectState;
+	stateName?: string;
 	comment: string;
 	collectionDate: Date;
 }


### PR DESCRIPTION
## 说明

这个 PR 修复豆瓣图书详情页中几个个人状态字段的解析问题：

- 修复 `myComment` 可能被解析成 `标签:`、`评价:` 等元信息文本的问题。
- 修复 `myTags` 无法正确解析图书个人标签的问题。
- 修复图书条目的 `myState` 显示为 `wish` / `do` / `collect` 等内部状态值的问题，现在会输出 `想读` / `在读` / `读过`。

## 背景

目前豆瓣图书详情页会把个人状态、评分提示、标签和短评都渲染在 `#interest_sect_level` 区域内。

原来的解析逻辑依赖 `span#rating` 附近固定的兄弟节点位置，例如通过 `.next()` 取标签和短评。这个方式在当前页面结构下不够稳定，容易导致：

- `myComment` 被解析成 `标签: 社会学 入门` 或 `评价:`。
- `myTags` 为空。
- `myState` 受语言包影响，显示为内部枚举值。

## 修改内容

- 图书标签改为从 `#interest_sect_level span.color_gray` 中查找以 `标签:` / `标签：` 开头的文本。
- 图书短评改为从个人状态区域中筛选候选文本，排除日期、标签、评分提示和状态文案后再取用户短评。
- 为 `UserStateSubject` 增加可选的 `stateName` 字段。
- 渲染 `{{myState}}` 时优先使用 `stateName`，没有该字段时仍回退到原有逻辑。
- 图书状态根据豆瓣页面文案归一化：
  - `我想读这本书` -> `想读`
  - `我在读这本书` -> `在读`
  - `我读过这本书` -> `读过`

## 测试

已在 Obsidian 中使用真实豆瓣图书条目手动测试，确认：

- `myComment` 输出实际短评。
- `myTags` 输出正确标签。
- `myState` 输出 `想读` / `在读` / `读过`。

同时执行构建检查：

```bash
npm run build